### PR TITLE
define STRICT_R_HEADERS, include float.h, adjust dbl eps constant

### DIFF
--- a/src/areaVgm.cpp
+++ b/src/areaVgm.cpp
@@ -1,4 +1,6 @@
 // [[Rcpp::plugins(openmp)]]
+#define STRICT_R_HEADERS
+#include <float.h>
 #include <Rcpp.h>
 #include <math.h>
 
@@ -165,13 +167,13 @@ double sp_gcdist(double lon1, double lon2, double lat1, double lat2) {
 	a = 6378.137;              /* WGS-84 equatorial radius in km */
 	f = 1.0 / 298.257223563;     /* WGS-84 ellipsoid flattening factor */
 
-	if (fabs(lat1 - lat2) < DOUBLE_EPS) {
-		if (fabs(lon1 - lon2) < DOUBLE_EPS) {
+	if (fabs(lat1 - lat2) < DBL_EPSILON) {
+		if (fabs(lon1 - lon2) < DBL_EPSILON) {
 			dist = 0.0;
 			return dist;
 			/* Wouter Buytaert bug caught 100211 */
 		}
-		else if (fabs((fabs(lon1) + fabs(lon2)) - 360.0) < DOUBLE_EPS) {
+		else if (fabs((fabs(lon1) + fabs(lon2)) - 360.0) < DBL_EPSILON) {
 			dist = 0.0;
 			return dist;
 		}


### PR DESCRIPTION
Dear Maogui,

As you know from yesterday's email (to which you already responded -- much appreciated), your CRAN package atakrig uses Rcpp, and uses in (just one file) definitions of DOUBLE_EPS that would go away if we enabled STRICT_R_HEADERS -- as we would like to. Please see the discussion at ~https://github.com/RcppCore/Rcpp/issues/898~ https://github.com/RcppCore/Rcpp/issues/1158 and the links therein for more context.

By simply including the standard header <float.h> and defining STRICT_R_HEADERS we can switch to DBL_EPSILON as the email patch and, for easier use, PR here show.

It would be lovely if you could apply this. There is no strong urgency: we aim to get this done over all affected packages in the space of a few months. If you apply it, would you mind dropping me a note by email or swinging by ~https://github.com/RcppCore/Rcpp/issues/898~ https://github.com/RcppCore/Rcpp/issues/1158 to confirm? 

Many thanks for your help, and I hope you continue to find Rcpp helpful. Please don't hesitate to ask if you have any questions.

_Edit 2021-04-29:_ Link to 1158 instead of 989